### PR TITLE
Increase symbol length to 12

### DIFF
--- a/.vuepress/components/Page.vue
+++ b/.vuepress/components/Page.vue
@@ -165,7 +165,7 @@
               type: 'ERC20',
               options: {
                 address: this.token.address,
-                symbol: this.token.symbol.substr(0, 5),
+                symbol: this.token.symbol.substr(0, 12),
                 decimals: this.token.decimals,
                 image: this.token.logo,
               },


### PR DESCRIPTION
MetaMask supports longer symbols, this adds more length to the symbols to match